### PR TITLE
✨ Map buttons에 필터링 기능 모두 구현 완료

### DIFF
--- a/public/assets/data/room.json
+++ b/public/assets/data/room.json
@@ -2,13 +2,13 @@
     {
         "saleNumber": "0000001",
         "coordinate": {
-            "latitude": 37.585487533417336,
-            "longitude": 127.01027743859059
+            "latitude": 37.59043422385236,
+            "longitude": 127.0069860636522
         },
-        "photo": "images/rooms/1-1.jpg",
+        "photo": "/images/rooms/1-1.jpg",
         "lease": "전세",
         "price": "2억5000",
-        "description": "내부상태 좋음 보증보험 가능함",
+        "description": "투룸 전세 내부상태 좋음 보증보험 가능함",
         "type": "오피스텔",
         "exclusiveArea": "29.89m²",
         "floor": "5층/5층",
@@ -35,7 +35,7 @@
             "latitude": 37.59453942049957,
             "longitude": 127.01738968649765
         },
-        "photo": "images/rooms/2-1.jpg",
+        "photo": "/images/rooms/2-1.jpg",
         "lease": "월세",
         "price": "1000/60",
         "description": "초역세권, 위치최고, 풀옵션",
@@ -62,13 +62,13 @@
     {
         "saleNumber": "0000003",
         "coordinate": {
-            "latitude": 37.60140543774192,
-            "longitude": 127.01388075338339
+            "latitude": 37.59282561005513,
+            "longitude": 127.01501145902839
         },
-        "photo": "images/rooms/3-1.jpg",
+        "photo": "/images/rooms/3-1.jpg",
         "lease": "월세",
         "price": "3000/95",
-        "description": "정릉역 3분. 주차가능. 방2. 넓은거실. 채광 좋음. 엘베 유",
+        "description": "성신여대입구역 3분. 주차가능. 방2. 넓은거실. 채광 좋음. 엘베 유",
         "type": "투룸",
         "exclusiveArea": "55.28m²",
         "floor": "3층/5층",
@@ -81,7 +81,7 @@
         "totalParking": "총 8대",
         "movingIn": "2024.12.30 (협의 가능)",
         "option": ["신발장"],
-        "summary": "3층, 55.28m², 관리비 20만\n정릉역 3분 거리",
+        "summary": "3층, 55.28m², 관리비 20만\n성신여대입구역 3분 거리",
         "infrastructure": {
             "subway": "100m",
             "convenienceStore": "50m",
@@ -92,10 +92,10 @@
     {
         "saleNumber": "0000004",
         "coordinate": {
-            "latitude": 37.58046327988857,
-            "longitude": 127.01981196232742
+            "latitude": 37.595961107599784,
+            "longitude": 127.01464124528333
         },
-        "photo": "images/rooms/4-1.jpg",
+        "photo": "/images/rooms/4-1.jpg",
         "lease": "월세",
         "price": "1억/70",
         "description": "2층 단독사용 넓은 거실과 넓은 투룸",
@@ -111,7 +111,7 @@
         "totalParking": "-",
         "movingIn": "즉시 입주 (협의 가능)",
         "option": ["싱크대"],
-        "summary": "2층, 82.64m², 관리비 없음\n보문역 20분 거리",
+        "summary": "2층, 82.64m², 관리비 없음\n성신여대입구역 20분 거리",
         "infrastructure": {
             "subway": "900m",
             "convenienceStore": "70m",
@@ -122,10 +122,10 @@
     {
         "saleNumber": "0000005",
         "coordinate": {
-            "latitude": 37.58508308582959,
-            "longitude": 127.03054910310289
+            "latitude": 37.59265475668677,
+            "longitude": 127.01209292974322
         },
-        "photo": "images/rooms/5-1.jpg",
+        "photo": "/images/rooms/5-1.jpg",
         "lease": "월세",
         "price": "500/35",
         "description": "뽀송 쾌적 습기 전혀 없음 확인 도배 완료",
@@ -141,7 +141,7 @@
         "totalParking": "-",
         "movingIn": "즉시 입주 (협의 가능)",
         "option": ["신발장", "냉장고", "세탁기", "싱크대"],
-        "summary": "반지층, 23.14m², 관리비 없음\n안암역 15분 거리",
+        "summary": "반지층, 23.14m², 관리비 없음\n한성대입구역 20분 거리",
         "infrastructure": {
             "subway": "700m",
             "convenienceStore": "300m",
@@ -152,10 +152,10 @@
     {
         "saleNumber": "0000006",
         "coordinate": {
-            "latitude": 37.600811735650545,
-            "longitude": 127.03211544225256
+            "latitude": 37.5883497657727,
+            "longitude": 127.01625884539172
         },
-        "photo": "images/rooms/6-1.jpg",
+        "photo": "/images/rooms/6-1.jpg",
         "lease": "전세",
         "price": "1억5000",
         "description": "리모델링 넓은투룸,풀옵션,대출불가",
@@ -171,7 +171,7 @@
         "totalParking": "-",
         "movingIn": "즉시 입주",
         "option": ["신발장", "냉장고", "세탁기", "싱크대", "인덕션", "에어컨"],
-        "summary": "1층, 42.97m², 관리비 5만원\n길음역 25분 거리",
+        "summary": "1층, 42.97m², 관리비 5만원\n보문역 16분 거리",
         "infrastructure": {
             "subway": "1km",
             "convenienceStore": "700m",
@@ -182,10 +182,10 @@
     {
         "saleNumber": "0000007",
         "coordinate": {
-            "latitude": 37.60418001034693,
-            "longitude": 127.0435944878551
+            "latitude": 37.58828303813341,
+            "longitude": 127.00802751470901
         },
-        "photo": "images//rooms/7-1.jpg",
+        "photo": "/images/rooms/7-1.jpg",
         "lease": "전세",
         "price": "6000",
         "description": "발 빠르게 깨끗하고 조용한 풀옵션 보세요",
@@ -201,7 +201,7 @@
         "totalParking": "총 1대",
         "movingIn": "2025.03.01",
         "option": ["신발장", "냉장고", "세탁기", "싱크대", "인덕션", "에어컨"],
-        "summary": "2층, 23.14m², 관리비 6만원\n월곡역 5분 거리",
+        "summary": "2층, 23.14m², 관리비 6만원\n한성대입구역 5분 거리",
         "infrastructure": {
             "subway": "300m",
             "convenienceStore": "50m",
@@ -212,10 +212,10 @@
     {
         "saleNumber": "0000008",
         "coordinate": {
-            "latitude": 37.608052988377,
-            "longitude": 127.06162096405791
+            "latitude": 37.589334562209125,
+            "longitude": 127.01246037265078
         },
-        "photo": "images/rooms/8-1.jpg",
+        "photo": "/images/rooms/8-1.jpg",
         "lease": "전세",
         "price": "1억7000",
         "description": "깔끔하고 채광 좋은 투룸 전세",
@@ -231,7 +231,7 @@
         "totalParking": "-",
         "movingIn": "즉시 입주 (협의 가능)",
         "option": [],
-        "summary": "1층, 37m², 관리비 3만원\n돌곶이역 20분 거리",
+        "summary": "1층, 37m², 관리비 3만원\n한성대입구역 15분 거리",
         "infrastructure": {
             "subway": "900m",
             "convenienceStore": "10m",

--- a/src/pages/map/FindHousePage.jsx
+++ b/src/pages/map/FindHousePage.jsx
@@ -2,14 +2,12 @@ import React, { useRef } from "react";
 import KakaoMap from "./KakaoMap";
 import styled from "styled-components";
 
-// 전체 컨테이너
 const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
   height: 100vh; /* 화면 전체 높이 */
 `;
 
-// 지도 컨테이너
 const MapContainer = styled.div`
   flex: 1; /* 남은 공간을 모두 차지 */
 `;

--- a/src/pages/map/KakaoMap.jsx
+++ b/src/pages/map/KakaoMap.jsx
@@ -25,6 +25,7 @@ const KakaoMap = ({ style, rooms }) => {
 
         // 데이터 불러오기 함수
         const fetchPolygonData = async () => {
+          
           try {
             const response = await fetch('/assets/data/map.json'); // JSON 파일 경로
             if (!response.ok) {
@@ -38,14 +39,13 @@ const KakaoMap = ({ style, rooms }) => {
           }
         };
 
-        // 폴리곤 데이터를 지도에 그리기
         const polygonData = await fetchPolygonData();
-
+        
+      
         polygonData.forEach((polygon) => {
           const path = polygon.coordinates.map(
             (coord) => new window.kakao.maps.LatLng(coord.lat, coord.lng)
           );
-
           let fillColor, strokeColor, fillOpacity, strokeOpacity;
 
           switch (polygon.safety) {
@@ -89,7 +89,6 @@ const KakaoMap = ({ style, rooms }) => {
           });
         });
 
-        // 방 데이터를 기반으로 마커 생성
         if (rooms && rooms.length > 0) {
           rooms.forEach((room) => {
             const position = new window.kakao.maps.LatLng(
@@ -103,10 +102,9 @@ const KakaoMap = ({ style, rooms }) => {
               title: room.type || '방',
             });
 
-            // 마커 클릭 이벤트 추가
             window.kakao.maps.event.addListener(marker, 'click', () => {
-              setSelectedRoom(room); // 선택된 방 설정
-              setIsModalOpen(true); // 모달 열기
+              setSelectedRoom(room); 
+              setIsModalOpen(true); 
             });
           });
         }
@@ -116,7 +114,6 @@ const KakaoMap = ({ style, rooms }) => {
     document.head.appendChild(script);
   }, [rooms]);
 
-  // 모달 닫기 핸들러
   const closeModal = () => {
     setIsModalOpen(false);
     setSelectedRoom(null);

--- a/src/pages/map/MapButtons.jsx
+++ b/src/pages/map/MapButtons.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
+import React, { useState } from "react";
+import styled from "styled-components";
 import infraIcon from "../../assets/icons/infra.png";
 import safetyIcon from "../../assets/icons/safety.png";
 import heartIcon from "../../assets/icons/heart.png";
@@ -20,17 +20,19 @@ const FloatingButton = styled.button`
   justify-content: center;
   width: 100px;
   padding: 10px;
-  background-color: white;
-  border: 1px solid #ddd;
+  background-color: ${(props) => (props.active ? "#4a60f6" : "white")};
+  color: ${(props) => (props.active ? "white" : "black")};
+  border: 1px solid ${(props) => (props.active ? "#374ab6" : "#ddd")};
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  box-shadow: ${(props) =>
+    props.active ? "0 4px 6px rgba(0, 0, 0, 0.3)" : "0 2px 4px rgba(0, 0, 0, 0.2)"};
   font-size: 14px;
   font-weight: bold;
   cursor: pointer;
   transition: background-color 0.2s, transform 0.2s;
 
   &:hover {
-    background-color: #f5f5f5;
+    background-color: ${(props) => (props.active ? "#374ab6" : "#f5f5f5")};
     transform: translateY(-2px);
   }
 
@@ -41,18 +43,78 @@ const FloatingButton = styled.button`
   }
 `;
 
-const MapButtons = ({ onFilterChange }) => {
+const SubButtonContainer = styled.div`
+  position: absolute;
+  bottom: calc(100% + 10px); /* "인프라" 버튼 위로 이동 */
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const SubButton = styled(FloatingButton)`
+  width: 90px; /* 더 작은 크기 */
+  padding: 8px;
+  font-size: 12px;
+  justify-content: center;
+`;
+
+const MapButtons = ({onFilterChange,onInfraFilterChange,activeFilter,activeInfraFilter,}) => {
+  const [showInfraOptions, setShowInfraOptions] = useState(false);
+
+  const toggleInfraOptions = () => {
+    setShowInfraOptions((prev) => !prev);
+    if (!showInfraOptions) {
+      onFilterChange("infra"); 
+    } else {
+      onFilterChange(null); 
+    }
+  };
+
   return (
     <FloatingButtonContainer>
-      <FloatingButton onClick={() => onFilterChange("infra")}>
+      {showInfraOptions && (
+        <SubButtonContainer>
+          <SubButton
+            active={activeInfraFilter === "subway"}
+            onClick={() => onInfraFilterChange("subway")}
+          >
+            지하철
+          </SubButton>
+          <SubButton
+            active={activeInfraFilter === "convenienceStore"}
+            onClick={() => onInfraFilterChange("convenienceStore")}
+          >
+            편의점
+          </SubButton>
+          <SubButton
+            active={activeInfraFilter === "hospital"}
+            onClick={() => onInfraFilterChange("hospital")}
+          >
+            병원
+          </SubButton>
+        </SubButtonContainer>
+      )}
+
+      <FloatingButton
+        active={activeFilter === "infra"}
+        onClick={toggleInfraOptions}
+      >
         <img src={infraIcon} alt="인프라" />
         인프라
       </FloatingButton>
-      <FloatingButton onClick={() => onFilterChange("safety")}>
+
+      <FloatingButton
+        active={activeFilter === "safety"}
+        onClick={() => onFilterChange("safety")}
+      >
         <img src={safetyIcon} alt="안전" />
         안전
       </FloatingButton>
-      <FloatingButton onClick={() => onFilterChange("favorites")}>
+
+      <FloatingButton
+        active={activeFilter === "favorites"}
+        onClick={() => onFilterChange("favorites")}
+      >
         <img src={heartIcon} alt="찜" />
         찜
       </FloatingButton>

--- a/src/pages/map/MapLayout.jsx
+++ b/src/pages/map/MapLayout.jsx
@@ -16,9 +16,11 @@ const MapContainer = styled.div`
 `;
 
 const MapLayout = () => {
-  const [rooms, setRooms] = useState([]);
-  const [filteredRooms, setFilteredRooms] = useState([]);
-  const [filter, setFilter] = useState(null);
+  const [rooms, setRooms] = useState([]); //fetch에서 사용해서 방목록 상태로 관리
+  const [filteredRooms, setFilteredRooms] = useState([]); // 각 컴포넌트에 전달될 필터링된 방들
+  const [activeFilter, setActiveFilter] = useState(null); //현재 켜진 버튼(찜,인프라,안전)
+  const [favorites, setFavorites] = useState([]); //찜된 방 번호들 --> saleNumber로 구분
+  const [activeInfraFilter, setActiveInfraFilter] = useState(null); // 인프라 필터 상태 (지하철,편의점,병원)
 
   useEffect(() => {
     const fetchData = async () => {
@@ -26,7 +28,7 @@ const MapLayout = () => {
         const response = await fetch("/assets/data/room.json");
         const data = await response.json();
         setRooms(data);
-        setFilteredRooms(data); // 초기 상태: 전체 데이터
+        setFilteredRooms(data); // 처음엔 데이터 전체로
       } catch (error) {
         console.error("Error fetching room data:", error);
       }
@@ -35,28 +37,82 @@ const MapLayout = () => {
   }, []);
 
   const handleFilterChange = (filterCondition) => {
-    setFilter(filterCondition);
+    if (activeFilter === filterCondition) {
+      // 이미 활성화된 버튼을 다시 누르면 해제
+      setActiveFilter(null);
+      setFilteredRooms(rooms); 
+      return;
+    }
+  
+    setActiveFilter(filterCondition);
+  
     switch (filterCondition) {
       case "infra":
-        setFilteredRooms(rooms.filter((room) => room.infra));
+        setActiveInfraFilter(null);
+        setFilteredRooms(rooms);
         break;
       case "safety":
-        setFilteredRooms(rooms.filter((room) => room.safety));
+        setFilteredRooms(
+          rooms.filter((room) => {
+            const facilityDistance = parseFloat(
+              room.infrastructure.publicSecurityFacility.replace("km", "")
+            );
+            return facilityDistance <= 1;
+          })
+        );
         break;
       case "favorites":
-        setFilteredRooms(rooms.filter((room) => room.isFavorite));
+        setFilteredRooms(rooms.filter((room) => favorites.includes(room.saleNumber)));
         break;
       default:
         setFilteredRooms(rooms);
     }
   };
+  
+  const toggleFavorite = (id) => {
+    setFavorites((prevFavorites) => {
+      if (prevFavorites.includes(id)) {
+        // 이미 찜한 상태면?? -> 제거
+        return prevFavorites.filter((favId) => favId !== id);
+      } else {
+        // 찜하지 않은 상태면?? -> 추가
+        return [...prevFavorites, id];
+      }
+    });
+  };
+  const handleInfraFilterChange = (infraType) => {
+    setActiveInfraFilter(infraType); // 현재 활성화된 인프라 버튼 설정
+
+    const MAX_DISTANCE = 0.5; // 500m 기준으로 해뒀습니다. 각각 설정하려면 복잡하기도 하겠지만... 일단?
+    setFilteredRooms(
+      rooms.filter((room) => {
+        const distanceStr = room.infrastructure[infraType]; 
+        if (!distanceStr) return false;
+
+        //거리가 m도 있고 km도 있어서 추가된 로직
+        //거리 파싱
+        const distance = parseFloat(distanceStr.replace("km", "").replace("m", "")) / 
+          (distanceStr.includes("km") ? 1 : 1000); 
+        return distance <= MAX_DISTANCE; // 최대 거리 이하 필터링
+      })
+    );
+  };
 
   return (
     <Layout>
-      <RoomList rooms={filteredRooms} />
+      <RoomList
+        rooms={filteredRooms}
+        favorites={favorites} // 찜 상태 전달
+        onToggleFavorite={toggleFavorite} // 하트 토글 함수 전달
+      />
       <MapContainer>
-        <FindHousePage rooms={rooms} />
-        <MapButtons onFilterChange={handleFilterChange} />
+        <FindHousePage rooms={filteredRooms} />
+        <MapButtons
+          onFilterChange={handleFilterChange}
+          onInfraFilterChange={handleInfraFilterChange} 
+          activeFilter={activeFilter}
+          activeInfraFilter={activeInfraFilter}
+        />
       </MapContainer>
     </Layout>
   );

--- a/src/pages/map/RoomList.jsx
+++ b/src/pages/map/RoomList.jsx
@@ -121,17 +121,9 @@ const RoomDetails = styled.div`
   color: black;
 `;
 
-const RoomList = ({ rooms }) => {
-  const [favorites, setFavorites] = useState({});
+const RoomList = ({ rooms,favorites, onToggleFavorite }) => {
   const [selectedRoom, setSelectedRoom] = useState(null); // 선택된 방 데이터
   const [isModalOpen, setModalOpen] = useState(false); // Modal 열림 여부
-
-  const toggleFavorite = (id) => {
-    setFavorites((prev) => ({
-      ...prev,
-      [id]: !prev[id],
-    }));
-  };
 
   const openModal = (room) => {
     setSelectedRoom(room); // 클릭된 방 데이터를 설정
@@ -161,13 +153,13 @@ const RoomList = ({ rooms }) => {
           <ListItemContainer key={room.saleNumber} onClick={() => openModal(room)}>
             <ListImage src={`/assets/${room.photo}`} alt={room.name || room.type} />
             <FavoriteButton
-              filled={favorites[room.saleNumber]}
+              filled={favorites.includes(room.saleNumber)} // 배열로 체크
               onClick={(e) => {
                 e.stopPropagation(); // Modal 열림 방지
-                toggleFavorite(room.saleNumber);
+                onToggleFavorite(room.saleNumber);
               }}
             >
-              {favorites[room.saleNumber] ? "❤️" : "🤍"}
+              {favorites.includes(room.saleNumber) ? "❤️" : "🤍"}
             </FavoriteButton>
             <RoomTextContainer>
               <RoomName>{room.price}</RoomName>


### PR DESCRIPTION
## ✨ Map buttons에 필터링 기능 모두 구현 완료

## 🔘Part

- [ ] FE
- [ ] Data
  <br/>

## 🔎 작업 내용

- 각 버튼을 누르면 지도에 설정된 맵들의 데이터가 필터링됩니다.

- MapLayout(부모 컴포넌트)에서 상태로 관리해서 데이터를 내려보내므로, 좌측에 방 리스트와 지도 마커 모두 변경됩니다.
- 안전은 Room.json publicSecurityFacility가 1.0km 이내인 경우에만 방들을 표시합니다.
- 인프라의 경우는 500m 이내인 경우고, 인프라 버튼을 클릭하면 지하철, 편의점, 병원 세 개의 버튼이 새로 생성됩니다.
- 찜은 하트 버튼을 누른 방 번호(saleNumber)들을 상태배열로 관리해서 구현했습니다. 당연히 새로고침 하면 없어집니다.

  <br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/2ae0d0c2-ceb5-404b-8970-bec9c048b93c)


## 🔧 TO DO

- 월세/전세 버튼 활성화....? 이거 필요한가
- 햄버거버튼 기능 구현...? 이것도 필요한가

  <br/>
